### PR TITLE
feat: Add cone phantom simulator (kVp/mAs + Poisson/Gaussian noise)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": "Python: simulate.py",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/simulate.py",
+            "console": "integratedTerminal",
+            "args": ["--kvp", "80", "--mas", "10", "--out", "demo.png"]
+        }
+    ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+contourpy==1.3.2
+cycler==0.12.1
+fonttools==4.58.0
+kiwisolver==1.4.8
+matplotlib==3.10.3
+numpy==2.2.6
+packaging==25.0
+pillow==11.2.1
+pyparsing==3.2.3
+python-dateutil==2.9.0.post0
+six==1.17.0

--- a/simulate.py
+++ b/simulate.py
@@ -1,0 +1,43 @@
+import argparse
+import numpy as np
+import matplotlib.pyplot as plt
+from simulator.physics import air_kerma
+from simulator.phantom import cone_thickness_map
+from simulator.noise import add_quantum_noise, add_system_noise
+
+MU_MM_INV = 0.005 # linear attenuation coefficient [1/mm], toy value
+
+def simulate(kvp: float, mas: float,
+             height_pix=512, width_pix=512) -> np.ndarray:
+    # --- 1. Photon fluence ---
+    photons = air_kerma(kvp, mas)
+
+    # --- 2. Cone phantom thickness map ---
+    thickness = cone_thickness_map(height_pix, width_pix)
+
+    # --- 3. Bear-Lamber attenuation ---
+    transmission = np.exp(-MU_MM_INV * thickness)
+
+    # --- 4. Scale to photon counts ---
+    primary_signal = photons * transmission
+    primary_norm = primary_signal / primary_signal.max()
+
+    # --- 5. Quantum noise ---
+    quantum_noisy = add_quantum_noise(primary_norm, photons_per_pixel=photons)
+
+    # --- 6. System noise ---
+    final_img = add_system_noise(quantum_noisy, sigma=0.02)
+
+    return final_img
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Cone X-ray image simulator")
+    parser.add_argument("--kvp", type=float, required=True, help="Tube voltage (kVp)")
+    parser.add_argument("--mas", type=float, required=True, help="Tube current-time product (mAs)")
+    parser.add_argument("--out", type=str, default="output.png", help="Output PNG filename")
+    args = parser.parse_args()
+
+    img = simulate(args.kvp, args.mas)
+
+    plt.imsave(args.out, img, cmap="gray")
+    print(f"Saved image to {args.out}")

--- a/simulator/noise.py
+++ b/simulator/noise.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+def add_quantum_noise(image: np.ndarray, photons_per_pixel: float,
+                      rng=np.random.default_rng()) -> np.ndarray:
+    """
+    Poisson noise proportional to photon count.
+    Assumes 'image' is signal in arbitary units propotional to photons.
+    """
+    # Convert to expected photon counts
+    expected = image * photons_per_pixel / image.max()
+    noisy = rng.poisson(expected)
+    # Rescale back to 0-1
+    return noisy / noisy.max()
+
+def add_system_noise(image: np.ndarray, sigma: float = 0.01,
+                     rng=np.random.default_rng()) -> np.ndarray:
+    
+    return np.clip(image + rng.normal(0, sigma, image.shape), 0, 1)

--- a/simulator/phantom.py
+++ b/simulator/phantom.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+def cone_thickness_map(height_px=512, width_px=512,
+                       base_mm=40.0, height_mm=80.0) -> np.ndarray:
+        """
+        Returns thickness [mm] map for a right circular core observed from the side.
+        x-axis: width direction, y-axis: projection height.
+
+        Linear thickness profile: at each y, the chord length through the cone.
+        """
+        y = np.linspace(0, height_mm, height_px)
+        radius_at_y = (1 - y / height_mm) * (base_mm / 2.0)
+        thickness_mm = radius_at_y * 2.0
+        # Broadcast thickness to every column
+        return np.repeat(thickness_mm[:, None], width_px, axis=1)

--- a/simulator/physics.py
+++ b/simulator/physics.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+def air_kerma(kvp: float, mas: float) -> float:
+    """
+    Very corse empirical model:
+        Air kerma = k *(kVp)^2 *mAs
+        
+    k is chosen so that output is on the order of 1e6 photons/pixel for 
+    typical parameters. Turn later with measured data.
+    """
+    k = 1.2e2
+    return k * (kvp ** 2) * mas


### PR DESCRIPTION
### What & Why
Implements Issue #1. Generates a side-view projection of a solid cone and
applies quantum (Poisson) and system (Gaussian) noise.

### Scope
- physics.py: rough air-kerma model
- phantom.py: analytical cone thickness map
- noise.py: Poisson & Gaussian noise helpers
- simulate.py: CLI + matplotlib output

closes #1